### PR TITLE
Uso de JDK 1.7. Y control de keyUsage != null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,4 +29,18 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/src/main/java/ec/rubrica/cert/bce/BceCaCert.java
+++ b/src/main/java/ec/rubrica/cert/bce/BceCaCert.java
@@ -224,22 +224,18 @@ public class BceCaCert extends X509Certificate {
 		certificate.verify(key, sigProvider);
 	}
 
-	@Override
 	public Set<String> getCriticalExtensionOIDs() {
 		return certificate.getCriticalExtensionOIDs();
 	}
 
-	@Override
 	public byte[] getExtensionValue(String oid) {
 		return certificate.getExtensionValue(oid);
 	}
 
-	@Override
 	public Set<String> getNonCriticalExtensionOIDs() {
 		return certificate.getNonCriticalExtensionOIDs();
 	}
 
-	@Override
 	public boolean hasUnsupportedCriticalExtension() {
 		return certificate.hasUnsupportedCriticalExtension();
 	}

--- a/src/main/java/ec/rubrica/cert/bce/BceCaTestCert.java
+++ b/src/main/java/ec/rubrica/cert/bce/BceCaTestCert.java
@@ -219,22 +219,18 @@ public class BceCaTestCert extends X509Certificate {
 		certificate.verify(key, sigProvider);
 	}
 
-	@Override
 	public Set<String> getCriticalExtensionOIDs() {
 		return certificate.getCriticalExtensionOIDs();
 	}
 
-	@Override
 	public byte[] getExtensionValue(String oid) {
 		return certificate.getExtensionValue(oid);
 	}
 
-	@Override
 	public Set<String> getNonCriticalExtensionOIDs() {
 		return certificate.getNonCriticalExtensionOIDs();
 	}
 
-	@Override
 	public boolean hasUnsupportedCriticalExtension() {
 		return certificate.hasUnsupportedCriticalExtension();
 	}

--- a/src/main/java/ec/rubrica/cert/bce/BceSubCert.java
+++ b/src/main/java/ec/rubrica/cert/bce/BceSubCert.java
@@ -222,22 +222,18 @@ public class BceSubCert extends X509Certificate {
 		certificate.verify(key, sigProvider);
 	}
 
-	@Override
 	public Set<String> getCriticalExtensionOIDs() {
 		return certificate.getCriticalExtensionOIDs();
 	}
 
-	@Override
 	public byte[] getExtensionValue(String oid) {
 		return certificate.getExtensionValue(oid);
 	}
 
-	@Override
 	public Set<String> getNonCriticalExtensionOIDs() {
 		return certificate.getNonCriticalExtensionOIDs();
 	}
 
-	@Override
 	public boolean hasUnsupportedCriticalExtension() {
 		return certificate.hasUnsupportedCriticalExtension();
 	}

--- a/src/main/java/ec/rubrica/cert/bce/BceSubTestCert.java
+++ b/src/main/java/ec/rubrica/cert/bce/BceSubTestCert.java
@@ -223,22 +223,18 @@ public class BceSubTestCert extends X509Certificate {
 		certificate.verify(key, sigProvider);
 	}
 
-	@Override
 	public Set<String> getCriticalExtensionOIDs() {
 		return certificate.getCriticalExtensionOIDs();
 	}
 
-	@Override
 	public byte[] getExtensionValue(String oid) {
 		return certificate.getExtensionValue(oid);
 	}
 
-	@Override
 	public Set<String> getNonCriticalExtensionOIDs() {
 		return certificate.getNonCriticalExtensionOIDs();
 	}
 
-	@Override
 	public boolean hasUnsupportedCriticalExtension() {
 		return certificate.hasUnsupportedCriticalExtension();
 	}

--- a/src/main/java/ec/rubrica/keystore/KeyStoreUtilities.java
+++ b/src/main/java/ec/rubrica/keystore/KeyStoreUtilities.java
@@ -32,8 +32,7 @@ import java.util.logging.Logger;
  */
 public class KeyStoreUtilities {
 
-	private static final Logger log = Logger.getLogger(KeyStoreUtilities.class
-			.getName());
+	private static final Logger log = Logger.getLogger(KeyStoreUtilities.class.getName());
 
 	public static boolean tieneAliasRepetidos(KeyStore keyStore) {
 		try {
@@ -60,14 +59,11 @@ public class KeyStoreUtilities {
 			field.setAccessible(true);
 			keyStoreVeritable = (KeyStoreSpi) field.get(keyStore);
 
-			if ("sun.security.mscapi.KeyStore$MY".equals(keyStoreVeritable
-					.getClass().getName())) {
+			if ("sun.security.mscapi.KeyStore$MY".equals(keyStoreVeritable.getClass().getName())) {
 				Collection<Object> entries;
 				String alias, hashCode;
 				X509Certificate[] certificates;
-
-				field = keyStoreVeritable.getClass().getEnclosingClass()
-						.getDeclaredField("entries");
+				field = keyStoreVeritable.getClass().getEnclosingClass().getDeclaredField("entries");
 				field.setAccessible(true);
 				entries = (Collection<Object>) field.get(keyStoreVeritable);
 
@@ -105,16 +101,14 @@ public class KeyStoreUtilities {
 
 			while (aliases.hasMoreElements()) {
 				String alias = aliases.nextElement();
-				X509Certificate certificate = (X509Certificate) keyStore
-						.getCertificate(alias);
+				X509Certificate certificate = (X509Certificate) keyStore.getCertificate(alias);
 
-				String name = certificate.getSubjectDN().getName();
+				if (certificate != null) {
+					String name = certificate.getSubjectDN().getName();
 
-				boolean[] keyUsage = certificate.getKeyUsage();
+					boolean[] keyUsage = certificate.getKeyUsage();
 
-				if (keyUsage != null) {
-					// Certificado para Firma Digital
-					if (keyUsage[0]) {
+					if (keyUsage != null && keyUsage[0]) {
 						aliasList.add(new Alias(alias, name));
 					}
 				}


### PR DESCRIPTION
En KeyStoreUtilities se asume siempre un keyUsage diferente de null, se aumentó un control de not null.
